### PR TITLE
golang-http-81-xieweicarl2018 to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,6 +10,9 @@ dependencies:
 - name: golang-http-80-xieweicarl2018
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: golang-http-81-xieweicarl2018
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1
 - name: serverless-jenkins-demo
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1


### PR DESCRIPTION
Promote golang-http-81-xieweicarl2018 to version 0.0.1