### PR TITLE
golang-http-81-xieweicarl2018 to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
   version: 0.0.1
 - name: golang-http-81-xieweicarl2018
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2
 - name: golang-http-82-xieweicarl2018
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.6


### PR DESCRIPTION
Promote golang-http-81-xieweicarl2018 to version 0.0.2