### PR TITLE
golang-http-82-xieweicarl2018 to 0.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 0.0.2
 - name: golang-http-82-xieweicarl2018
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.7
+  version: 0.0.8
 - name: node-http
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
Promote golang-http-82-xieweicarl2018 to version 0.0.8